### PR TITLE
Proceed postflight for clash-mac

### DIFF
--- a/Casks/clash-mac.rb
+++ b/Casks/clash-mac.rb
@@ -21,6 +21,9 @@ cask "clash-mac" do
   homepage "https://github.com/666OS/ClashMac"
 
   postflight do
+    # Informative message for users during installation
+    puts "Run `xattr -cr /Applications/ClashMac.app` for the APP, see more details in https://github.com/666OS/ClashMac/blob/main/README.md#solutions."
+
     # TODO: https://github.com/666OS/ClashMac/blob/main/README.md#solutions
     system_command '/usr/bin/xattr', args: ['-cr', "#{appdir}/ClashMac.app"], sudo: false
   end


### PR DESCRIPTION
Follow up #59.

```bash
xattr -cr /Applications/ClashMac.app
```
or

```bash
xattr -d com.apple.quarantine /Applications/ClashMac.app
```