### PR TITLE
Replace macos-latest with macos-26

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -29,8 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         packages: ${{ fromJSON(needs.changed-packages.outputs.matrix) }}
-        os: # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-          - macos-latest # Based on arm64.
+        os: # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+          - macos-26 # Based on arm64.
           - macos-15-intel # Based on x64.
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Refs #120.