### PR TITLE
Rely on auto-bump via workflow_call

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -5,10 +5,7 @@ on:
     # Run every hour.
     - cron: "0 * * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_call:
 
 jobs:
   bump-packages:

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
 
 jobs:
+  auto-bump:
+    uses: ./.github/workflows/auto-bump.yml
+    secrets: inherit # https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-secrets-to-nested-workflows
+
   changed-packages:
     runs-on: ubuntu-latest
     outputs:
@@ -59,6 +63,7 @@ jobs:
   # Status check that is required in branch protection rules.
   final-status:
     needs:
+      - auto-bump
       - changed-packages
       - verify-packages
     runs-on: ubuntu-latest


### PR DESCRIPTION
`final-status` should also ensure `auto-bump` job passed.