### PR TITLE
Replace Homebrew/actions/setup-homebrew with direct commands

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -42,7 +42,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: Homebrew/actions/setup-homebrew@main
+      - name: Set up Homebrew Tap
+        run: |
+          brew update-reset "$(brew --repository)"
+          mkdir -p $(brew --repo)/Library/Taps/goooler
+          ln -s $GITHUB_WORKSPACE $(brew --repo)/Library/Taps/goooler/homebrew-repo
       - name: Check Package
         run: |
           PACKAGE_NAME="$(basename "${{ matrix.packages }}" .rb)"


### PR DESCRIPTION
This ensures the workflow works in forked repos.