### PR TITLE
Fix audit issues for clash-mi

### DIFF
--- a/Casks/clash-mi.rb
+++ b/Casks/clash-mi.rb
@@ -7,6 +7,12 @@ cask "clash-mi" do
   desc "Another Mihomo GUI based on Flutter"
   homepage "https://github.com/KaringX/clashmi"
 
+  # Disable pre-releases like v1.0.16.200.
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :monterey"
 
   app "Clash Mi.app"


### PR DESCRIPTION
```
audit for clash-mi: failed
 - Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version
 - v1.0.16.200 is a GitHub pre-release.
```

https://github.com/Goooler/homebrew-repo/actions/runs/20844077382/job/59883868426