### PR TITLE
Revert "Skip clash-mi v1.0.17.300 due to misnamed DMG asset"

### DIFF
--- a/Casks/clash-mi.rb
+++ b/Casks/clash-mi.rb
@@ -7,21 +7,10 @@ cask "clash-mi" do
   desc "Another Mihomo GUI based on Flutter"
   homepage "https://github.com/KaringX/clashmi"
 
-  # Skip version 1.0.17.300 as it has a misnamed DMG file (clashmi_1.0.16.300 instead of clashmi_1.0.17.300)
-  # See: https://github.com/KaringX/clashmi/releases/tag/v1.0.17.300
+  # Exclude pre-releases like v1.0.16.200
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-    strategy :github_latest do |json, regex|
-      match = json["tag_name"]&.match(regex)
-      next if match.blank?
-
-      version = match[1]
-      # Skip 1.0.17.300 due to incorrect asset filename
-      next if version == "1.0.17.300"
-
-      version
-    end
+    strategy :github_latest
   end
 
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
Reverts Goooler/homebrew-repo#191