### PR TITLE
Specify macOS version requirement for FlClash

### DIFF
--- a/Casks/fl-clash.rb
+++ b/Casks/fl-clash.rb
@@ -16,7 +16,7 @@ cask "fl-clash" do
     strategy :github_latest
   end
 
-  depends_on :macos
+  depends_on macos: :big_sur
 
   app "FlClash.app"
 


### PR DESCRIPTION
```
==> Downloading https://github.com/chen08209/FlClash/releases/download/v0.8.94/FlClash-0.8.94-macos-arm64.dmg
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/5216dfe4b43278bc0f7ef135811e765e2610a42c66ea57f917ca47ebfd782a71--FlClash-0.8.94-macos-arm64.dmg
audit for fl-clash: failed
 - Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version
goooler/repo/fl-clash
  * Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version
Error: 1 problem in 1 cask detected.
Error: Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version
Error: `brew audit` failed!
```

https://github.com/Goooler/homebrew-repo/actions/runs/29154352520/job/86548920827